### PR TITLE
fix: DNR 规则 8 增加 initiatorDomains，避免误伤 www 页搜索 API

### DIFF
--- a/public/referrer.json
+++ b/public/referrer.json
@@ -189,6 +189,7 @@
       ]
     },
     "condition": {
+      "initiatorDomains": ["search.bilibili.com"],
       "urlFilter": "https://api.bilibili.com/x/web-interface/search",
       "resourceTypes": ["xmlhttprequest"],
       "requestMethods": ["get"]


### PR DESCRIPTION
## 问题

`referrer.json` 规则 id: 8 对所有匹配 `https://api.bilibili.com/x/web-interface/search` 的 GET XHR 强制设置：

```
Origin: https://search.bilibili.com
Referer: https://search.bilibili.com
```

但未设置 `initiatorDomains`，因此在 `www.bilibili.com`（视频页、稍后再看等）上也会命中。

B 站搜索 API 按请求头返回 `Access-Control-Allow-Origin: https://search.bilibili.com`，而浏览器 CORS 仍以页面 **document origin**（`https://www.bilibili.com`）校验，导致请求失败（XHR `status: 0` / `Failed to fetch`）。

这与同文件 **规则 1** 的写法不一致——规则 1 已正确使用 `initiatorDomains: ["member.bilibili.com"]` 限制发起方。

## 复现

1. 启用扩展，打开 `https://www.bilibili.com/list/watchlater`
2. Console 执行：

```javascript
const url = 'https://api.bilibili.com/x/web-interface/search/type?search_type=video&keyword=test&page=1&page_size=5';
const x = new XMLHttpRequest();
x.open('GET', url);
x.withCredentials = true;
x.responseType = 'json';
x.onload = () => console.log('OK', x.status, x.response?.code);
x.onerror = () => console.log('FAIL', x.status);
x.send();
```

- **修复前**：`FAIL 0`，CORS 报错
- **修复后**：`OK 200 0`

关闭扩展后同一请求立即成功，可确认根因在扩展 DNR 规则而非 B 站接口本身。

## 修复

为规则 8 增加 `initiatorDomains: ["search.bilibili.com"]`，仅当请求从搜索页发起时才改头。

`injected.js` 的 fetch 劫持（仅 `history/delete`）与本次问题无关。

## 影响面

- **修复后仍正常**：`search.bilibili.com` 上的搜索（规则 8 原设计场景）
- **修复后恢复**：`www.bilibili.com` 上通过页面上下文 XHR/fetch 调用搜索 API 的用户脚本（如 Tampermonkey 组件）

已在本地构建未打包扩展验证通过。