### PR TITLE
feat:subscribed collections 新增：订阅合集管理

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Sun,
   Moon,
   Heart,
+  LibraryBig,
 } from "lucide-react";
 import { UserInfo } from "./UserInfo";
 import ExpandableMenu from "./ExpandableMenu";
@@ -30,6 +31,11 @@ const menuList = [
     title: "收藏夹",
     icon: <Star className="w-4 h-4" />,
     to: "/favorites",
+  },
+  {
+    title: "合集",
+    icon: <LibraryBig className="w-4 h-4" />,
+    to: "/collections",
   },
   {
     title: "AI探索",

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -327,15 +327,14 @@ export default defineBackground(() => {
     sendResponse: (response: any) => void,
   ) => {
     const collectionId = Number(message.collectionId);
-    const mid = Number(message.mid);
 
-    if (!Number.isFinite(collectionId) || !Number.isFinite(mid)) {
+    if (!Number.isFinite(collectionId)) {
       sendResponse({ success: false, error: "合集信息不完整" });
       return;
     }
 
     try {
-      await syncSubscribedCollectionResources(collectionId, mid);
+      await syncSubscribedCollectionResources(collectionId);
       sendResponse({ success: true, message: "合集内容同步成功" });
     } catch (error) {
       console.error("同步合集内容失败:", error);
@@ -737,24 +736,19 @@ export default defineBackground(() => {
     await replaceSubscribedCollections(collections);
   }
 
-  async function syncSubscribedCollectionResources(
-    collectionId: number,
-    mid: number,
-  ): Promise<void> {
+  async function syncSubscribedCollectionResources(collectionId: number): Promise<void> {
     const sessdata = await getBilibiliSession();
     const pageSize = 30;
     let page = 1;
-    let total = Infinity;
+    let hasMore = true;
     const resources: SubscribedCollectionResource[] = [];
-    const referer = `https://space.bilibili.com/${mid}/lists/${collectionId}?type=season`;
 
-    while (resources.length < total) {
+    while (hasMore) {
       const response = await fetch(
-        `https://api.bilibili.com/x/polymer/web-space/seasons_archives_list?mid=${mid}&season_id=${collectionId}&page_num=${page}&page_size=${pageSize}&sort_reverse=false`,
+        `https://api.bilibili.com/x/space/fav/season/list?season_id=${collectionId}&pn=${page}&ps=${pageSize}`,
         {
           headers: {
             Cookie: `SESSDATA=${sessdata}`,
-            Referer: referer,
           },
         },
       );
@@ -763,25 +757,24 @@ export default defineBackground(() => {
       const data = await response.json();
       if (data.code !== 0) throw new Error(data.message || "获取合集内容失败");
 
-      const archives = data.data?.archives || [];
-      total = Number(data.data?.page?.total || 0);
+      const medias = data.data?.medias || [];
       resources.push(
-        ...archives.map((archive: any, index: number) => ({
-          id: `${collectionId}-${archive.aid}`,
+        ...medias.map((media: any, index: number) => ({
+          id: `${collectionId}-${media.id}`,
           collection_id: collectionId,
-          aid: archive.aid,
-          bvid: archive.bvid,
-          title: archive.title || "未命名视频",
-          cover: archive.pic || archive.cover || "",
-          duration: archive.duration || 0,
-          author_name: archive.owner?.name || archive.author || "未知 UP 主",
-          author_mid: archive.owner?.mid || archive.mid || 0,
-          pubdate: archive.pubdate || archive.ctime || 0,
+          aid: media.id,
+          bvid: media.bvid || media.bv_id || "",
+          title: media.title || "未命名视频",
+          cover: media.cover || "",
+          duration: media.duration || 0,
+          author_name: media.upper?.name || "未知 UP 主",
+          author_mid: media.upper?.mid || 0,
+          pubdate: media.pubtime || media.ctime || 0,
           index: resources.length + index,
         })),
       );
 
-      if (archives.length < pageSize) break;
+      hasMore = Boolean(data.data?.has_more);
       page += 1;
     }
 

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -33,9 +33,12 @@ import {
   smartMergeLikedMusic,
   smartMergeFavResources,
   importFavFolders,
+  replaceSubscribedCollections,
+  replaceSubscribedCollectionResources,
 } from "../utils/db";
 import { getStorageValue, setStorageValue } from "../utils/storage";
 import { WebDavConfig, ensureDirectory, uploadFile, downloadFile } from "../utils/webdav";
+import { SubscribedCollection, SubscribedCollectionResource } from "../utils/types";
 
 export default defineBackground(() => {
   console.log("Hello background!", { id: browser.runtime.id });
@@ -302,6 +305,43 @@ export default defineBackground(() => {
     }
   };
 
+  const handleSyncSubscribedCollections = async (sendResponse: (response: any) => void) => {
+    try {
+      await syncSubscribedCollections();
+      sendResponse({ success: true, message: "订阅合集同步成功" });
+    } catch (error) {
+      console.error("同步订阅合集失败:", error);
+      sendResponse({
+        success: false,
+        error: error instanceof Error ? error.message : "未知错误",
+      });
+    }
+  };
+
+  const handleSyncSubscribedCollectionResources = async (
+    message: any,
+    sendResponse: (response: any) => void,
+  ) => {
+    const collectionId = Number(message.collectionId);
+    const mid = Number(message.mid);
+
+    if (!Number.isFinite(collectionId) || !Number.isFinite(mid)) {
+      sendResponse({ success: false, error: "合集信息不完整" });
+      return;
+    }
+
+    try {
+      await syncSubscribedCollectionResources(collectionId, mid);
+      sendResponse({ success: true, message: "合集内容同步成功" });
+    } catch (error) {
+      console.error("同步合集内容失败:", error);
+      sendResponse({
+        success: false,
+        error: error instanceof Error ? error.message : "未知错误",
+      });
+    }
+  };
+
   // 处理删除历史记录的消息
   const handleDeleteHistoryItem = async (message: any, sendResponse: (response: any) => void) => {
     try {
@@ -334,6 +374,12 @@ export default defineBackground(() => {
       return true; // 保持消息通道开放
     } else if (message.action === "syncFavorites") {
       handleSyncFavorites(message, sendResponse);
+      return true;
+    } else if (message.action === "syncSubscribedCollections") {
+      handleSyncSubscribedCollections(sendResponse);
+      return true;
+    } else if (message.action === "syncSubscribedCollectionResources") {
+      handleSyncSubscribedCollectionResources(message, sendResponse);
       return true;
     }
   });
@@ -624,6 +670,118 @@ export default defineBackground(() => {
       console.error("同步收藏夹过程出错:", error);
       throw error;
     }
+  }
+
+  async function getBilibiliSession(): Promise<string> {
+    const cookies = await browser.cookies.getAll({ domain: "bilibili.com" });
+    const sessdata = cookies.find((cookie) => cookie.name === "SESSDATA")?.value;
+    if (!sessdata) throw new Error("未找到 B 站登录信息，请先登录 B 站");
+    return sessdata;
+  }
+
+  async function getCurrentBilibiliMid(sessdata: string): Promise<number> {
+    const navRes = await fetch("https://api.bilibili.com/x/web-interface/nav", {
+      headers: { Cookie: `SESSDATA=${sessdata}` },
+    });
+    if (!navRes.ok) throw new Error("获取用户信息失败");
+
+    const navData = await navRes.json();
+    if (navData.code !== 0 || !navData.data?.mid)
+      throw new Error(navData.message || "获取用户信息失败");
+    return navData.data.mid;
+  }
+
+  async function syncSubscribedCollections(): Promise<void> {
+    const sessdata = await getBilibiliSession();
+    const currentMid = await getCurrentBilibiliMid(sessdata);
+    const pageSize = 50;
+    let page = 1;
+    let total = Infinity;
+    const collections: SubscribedCollection[] = [];
+
+    while (collections.length < total) {
+      const response = await fetch(
+        `https://api.bilibili.com/x/v3/fav/folder/collected/list?pn=${page}&ps=${pageSize}&up_mid=${currentMid}&platform=web&web_location=333.1387`,
+        { headers: { Cookie: `SESSDATA=${sessdata}` } },
+      );
+      if (!response.ok) throw new Error("获取订阅合集失败");
+
+      const data = await response.json();
+      if (data.code !== 0) throw new Error(data.message || "获取订阅合集失败");
+
+      const list = data.data?.list || [];
+      total = Number(data.data?.count || 0);
+      collections.push(
+        ...list.map((item: any, index: number) => ({
+          id: item.id,
+          mid: item.mid,
+          title: item.title || "未命名合集",
+          cover: item.cover || "",
+          intro: item.intro || "",
+          ctime: item.ctime || 0,
+          mtime: item.mtime || 0,
+          media_count: item.media_count || 0,
+          upper: item.upper || { mid: item.mid, name: "未知 UP 主", face: "" },
+          index: collections.length + index,
+        })),
+      );
+
+      if (list.length < pageSize) break;
+      page += 1;
+    }
+
+    await replaceSubscribedCollections(collections);
+  }
+
+  async function syncSubscribedCollectionResources(
+    collectionId: number,
+    mid: number,
+  ): Promise<void> {
+    const sessdata = await getBilibiliSession();
+    const pageSize = 30;
+    let page = 1;
+    let total = Infinity;
+    const resources: SubscribedCollectionResource[] = [];
+    const referer = `https://space.bilibili.com/${mid}/lists/${collectionId}?type=season`;
+
+    while (resources.length < total) {
+      const response = await fetch(
+        `https://api.bilibili.com/x/polymer/web-space/seasons_archives_list?mid=${mid}&season_id=${collectionId}&page_num=${page}&page_size=${pageSize}&sort_reverse=false`,
+        {
+          headers: {
+            Cookie: `SESSDATA=${sessdata}`,
+            Referer: referer,
+          },
+        },
+      );
+      if (!response.ok) throw new Error("获取合集内容失败");
+
+      const data = await response.json();
+      if (data.code !== 0) throw new Error(data.message || "获取合集内容失败");
+
+      const archives = data.data?.archives || [];
+      total = Number(data.data?.page?.total || 0);
+      resources.push(
+        ...archives.map((archive: any, index: number) => ({
+          id: `${collectionId}-${archive.aid}`,
+          collection_id: collectionId,
+          aid: archive.aid,
+          bvid: archive.bvid,
+          title: archive.title || "未命名视频",
+          cover: archive.pic || archive.cover || "",
+          duration: archive.duration || 0,
+          author_name: archive.owner?.name || archive.author || "未知 UP 主",
+          author_mid: archive.owner?.mid || archive.mid || 0,
+          pubdate: archive.pubdate || archive.ctime || 0,
+          index: resources.length + index,
+        })),
+      );
+
+      if (archives.length < pageSize) break;
+      page += 1;
+    }
+
+    await replaceSubscribedCollectionResources(collectionId, resources);
   }
 
   // WebDAV 自动双向同步：拉取 → 合并 → 推送

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -29,10 +29,14 @@ import {
   getAllLikedMusic,
   getAllFavFolders,
   getAllFavResources,
+  getAllSubscribedCollections,
+  getAllSubscribedCollectionResources,
   smartMergeHistory,
   smartMergeLikedMusic,
   smartMergeFavResources,
   importFavFolders,
+  importSubscribedCollections,
+  smartMergeSubscribedCollectionResources,
   replaceSubscribedCollections,
   replaceSubscribedCollectionResources,
 } from "../utils/db";
@@ -823,6 +827,21 @@ export default defineBackground(() => {
         await smartMergeFavResources(items);
       }
 
+      const collectionsData = await downloadFile(config, "subscribedCollections.json");
+      if (collectionsData) {
+        const items = JSON.parse(collectionsData);
+        await importSubscribedCollections(items);
+      }
+
+      const collectionResourcesData = await downloadFile(
+        config,
+        "subscribedCollectionResources.json",
+      );
+      if (collectionResourcesData) {
+        const items = JSON.parse(collectionResourcesData);
+        await smartMergeSubscribedCollectionResources(items);
+      }
+
       // ===== 第二步：将合并后的最新本地数据推送到远端 =====
       console.log("[WebDAV 同步] 步骤 2/2：推送本地数据到远端...");
 
@@ -838,11 +857,21 @@ export default defineBackground(() => {
       const resources = await getAllFavResources();
       await uploadFile(config, "favResources.json", JSON.stringify(resources));
 
+      const collections = await getAllSubscribedCollections();
+      await uploadFile(config, "subscribedCollections.json", JSON.stringify(collections));
+
+      const collectionResources = await getAllSubscribedCollectionResources();
+      await uploadFile(
+        config,
+        "subscribedCollectionResources.json",
+        JSON.stringify(collectionResources),
+      );
+
       // 同步完成，记录时间戳
       await setStorageValue(WEBDAV_LAST_SYNC, Date.now());
 
       console.log(
-        `WebDAV 双向同步完成：历史 ${history.length}，音乐 ${music.length}，收藏夹 ${folders.length}，收藏 ${resources.length}`,
+        `WebDAV 双向同步完成：历史 ${history.length}，音乐 ${music.length}，收藏夹 ${folders.length}，收藏 ${resources.length}，订阅合集 ${collections.length}，合集视频 ${collectionResources.length}`,
       );
     } catch (error) {
       console.error("WebDAV 双向同步失败:", error);

--- a/entrypoints/my-history/App.tsx
+++ b/entrypoints/my-history/App.tsx
@@ -15,6 +15,7 @@ import Welcome from "../../pages/Welcome";
 import AISearch from "../../pages/AISearch";
 import Reward from "../../pages/Reward";
 import { UpdateNoticeModal } from "../../components/UpdateNoticeModal";
+import SubscribedCollections from "../../pages/SubscribedCollections";
 
 const MainLayout = ({ children }: { children: React.ReactNode }) => {
   const location = useLocation();
@@ -48,6 +49,7 @@ const App = () => {
             <Route path="/webdav-sync" element={<WebDavSync />} />
             <Route path="/reward" element={<Reward />} />
             <Route path="/favorites" element={<Favorites />} />
+            <Route path="/collections" element={<SubscribedCollections />} />
             <Route path="/ai-search" element={<AISearch />} />
             <Route path="/music/search" element={<SearchMusic />} />
             <Route path="/music/liked" element={<LikedMusic />} />

--- a/pages/Settings.tsx
+++ b/pages/Settings.tsx
@@ -382,7 +382,7 @@ const Settings = () => {
               onChange={handleHideUserInfoChange}
             />
 
-            {["收藏夹", "听歌", "云同步", "WebDAV", "关于", "反馈"].map((title) => (
+            {["收藏夹", "合集", "听歌", "云同步", "WebDAV", "关于", "反馈"].map((title) => (
               <Checkbox
                 key={title}
                 label={`隐藏${title}`}

--- a/pages/SubscribedCollections.tsx
+++ b/pages/SubscribedCollections.tsx
@@ -1,0 +1,373 @@
+import { useEffect, useRef, useState } from "react";
+import toast from "react-hot-toast";
+import { getSubscribedCollectionResources, getSubscribedCollections } from "../utils/db";
+import { SubscribedCollection, SubscribedCollectionResource } from "../utils/types";
+import { ChevronDownIcon, LibraryBig, RefreshCw, Search, X } from "lucide-react";
+import { Pagination } from "../components/Pagination";
+
+type SearchType = "all" | "title" | "up" | "bvid" | "avid";
+
+const SEARCH_OPTIONS: { value: SearchType; label: string }[] = [
+  { value: "all", label: "综合搜索" },
+  { value: "title", label: "视频标题" },
+  { value: "up", label: "UP 主" },
+  { value: "bvid", label: "视频 BV 号" },
+  { value: "avid", label: "视频 AV 号" },
+];
+
+export const SubscribedCollections = () => {
+  const [collections, setCollections] = useState<SubscribedCollection[]>([]);
+  const [selectedCollectionId, setSelectedCollectionId] = useState<number | null>(null);
+  const [resources, setResources] = useState<SubscribedCollectionResource[]>([]);
+  const [isSyncingCollections, setIsSyncingCollections] = useState(false);
+  const [isSyncingResources, setIsSyncingResources] = useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [keyword, setKeyword] = useState("");
+  const [searchType, setSearchType] = useState<SearchType>("all");
+  const [isSearchKindDropdownOpen, setIsSearchKindDropdownOpen] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const pageSize = 50;
+
+  const selectedCollection = collections.find(
+    (collection) => collection.id === selectedCollectionId,
+  );
+
+  const loadCollections = async () => {
+    const list = await getSubscribedCollections();
+    const sortedList = list.sort((a, b) => a.index - b.index);
+    setCollections(sortedList);
+    setSelectedCollectionId((currentId) => {
+      if (currentId && sortedList.some((collection) => collection.id === currentId))
+        return currentId;
+      return sortedList[0]?.id ?? null;
+    });
+  };
+
+  const loadResources = async (collectionId: number) => {
+    const list = await getSubscribedCollectionResources(collectionId);
+    setResources(list.sort((a, b) => a.index - b.index));
+    setCurrentPage(1);
+    setKeyword("");
+  };
+
+  const refreshCollections = async () => {
+    setIsSyncingCollections(true);
+    try {
+      const response = await browser.runtime.sendMessage({ action: "syncSubscribedCollections" });
+      if (!response?.success) throw new Error(response?.error || "同步订阅合集失败");
+      await loadCollections();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "同步订阅合集失败");
+    } finally {
+      setIsSyncingCollections(false);
+    }
+  };
+
+  const refreshResources = async (collection: SubscribedCollection) => {
+    setIsSyncingResources(true);
+    try {
+      const response = await browser.runtime.sendMessage({
+        action: "syncSubscribedCollectionResources",
+        collectionId: collection.id,
+        mid: collection.mid,
+      });
+      if (!response?.success) throw new Error(response?.error || "同步合集内容失败");
+      await loadResources(collection.id);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "同步合集内容失败");
+    } finally {
+      setIsSyncingResources(false);
+    }
+  };
+
+  useEffect(() => {
+    loadCollections().catch(() => toast.error("加载订阅合集缓存失败"));
+    refreshCollections();
+  }, []);
+
+  useEffect(() => {
+    if (!selectedCollection) {
+      setResources([]);
+      return;
+    }
+
+    loadResources(selectedCollection.id).catch(() => toast.error("加载合集内容缓存失败"));
+    refreshResources(selectedCollection);
+  }, [selectedCollectionId]);
+
+  const filteredResources = resources.filter((item) => {
+    if (!keyword) return true;
+    const lowerKeyword = keyword.toLowerCase();
+
+    switch (searchType) {
+      case "title":
+        return item.title.toLowerCase().includes(lowerKeyword);
+      case "up":
+        return item.author_name.toLowerCase().includes(lowerKeyword);
+      case "bvid":
+        return item.bvid.toLowerCase().includes(lowerKeyword);
+      case "avid":
+        return String(item.aid).includes(lowerKeyword);
+      case "all":
+      default:
+        return (
+          item.title.toLowerCase().includes(lowerKeyword) ||
+          item.author_name.toLowerCase().includes(lowerKeyword) ||
+          item.bvid.toLowerCase().includes(lowerKeyword) ||
+          String(item.aid).includes(lowerKeyword)
+        );
+    }
+  });
+
+  const startIndex = (currentPage - 1) * pageSize;
+  const currentResources = filteredResources.slice(startIndex, startIndex + pageSize);
+  const searchLabel =
+    SEARCH_OPTIONS.find((option) => option.value === searchType)?.label || "综合搜索";
+
+  return (
+    <div className="flex h-screen bg-gray-50 dark:bg-[#0a0a0a]">
+      <aside className="w-64 bg-white dark:bg-neutral-900 border-r border-gray-200 dark:border-neutral-800 overflow-y-auto flex-shrink-0">
+        <div className="p-4 border-b border-gray-200 dark:border-neutral-800 flex items-center justify-between gap-3">
+          <h2 className="text-lg font-bold flex items-center gap-2 min-w-0">
+            <LibraryBig className="w-5 h-5 shrink-0" />
+            <span className="truncate">我的订阅合集</span>
+          </h2>
+          <button
+            type="button"
+            title="同步订阅合集"
+            aria-label="同步订阅合集"
+            onClick={refreshCollections}
+            disabled={isSyncingCollections}
+            className="p-2 rounded-md text-gray-500 hover:bg-gray-100 hover:text-pink-500 disabled:opacity-50 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-pink-400 transition-colors"
+          >
+            <RefreshCw className={`w-4 h-4 ${isSyncingCollections ? "animate-spin" : ""}`} />
+          </button>
+        </div>
+
+        <div className="p-2">
+          {collections.map((collection) => (
+            <button
+              key={collection.id}
+              type="button"
+              onClick={() => setSelectedCollectionId(collection.id)}
+              className={`w-full p-3 rounded-lg text-left mb-1 transition-colors ${
+                selectedCollectionId === collection.id
+                  ? "bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400"
+                  : "hover:bg-gray-100 dark:hover:bg-neutral-800"
+              }`}
+            >
+              <div className="font-medium truncate">{collection.title}</div>
+              <div className="text-xs text-gray-400 dark:text-neutral-500 mt-1 truncate">
+                {collection.upper?.name || "未知 UP 主"} · {collection.media_count} 个视频
+              </div>
+            </button>
+          ))}
+
+          {!isSyncingCollections && collections.length === 0 && (
+            <div className="p-5 text-center text-sm text-gray-400 dark:text-neutral-500">
+              暂无订阅合集
+            </div>
+          )}
+        </div>
+      </aside>
+
+      <main className="flex-1 overflow-y-auto" ref={contentRef}>
+        <div className="p-6">
+          {selectedCollection ? (
+            <>
+              <section className="mb-6 flex flex-col md:flex-row justify-between md:items-center gap-4 bg-white dark:bg-neutral-900 p-4 rounded-xl shadow-sm border border-gray-100 dark:border-neutral-800">
+                <div className="min-w-0">
+                  <h1 className="text-xl font-bold flex items-center gap-2 min-w-0">
+                    <span className="truncate">{selectedCollection.title}</span>
+                    <span className="shrink-0 text-sm font-normal text-gray-500 dark:text-neutral-400 bg-gray-50 dark:bg-neutral-800 px-2 py-1 rounded-full border border-gray-100 dark:border-neutral-700">
+                      {filteredResources.length} 个视频
+                    </span>
+                  </h1>
+                  {selectedCollection.intro && (
+                    <p className="mt-2 text-sm text-gray-500 dark:text-neutral-400 line-clamp-1">
+                      {selectedCollection.intro}
+                    </p>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-3 w-full md:w-auto">
+                  <div className="relative flex-1 md:w-[32rem] group flex items-center bg-gray-50 dark:bg-neutral-800 border border-gray-200 dark:border-neutral-700 rounded-full transition-all duration-300 shadow-sm hover:shadow-md focus-within:bg-white dark:focus-within:bg-neutral-800 focus-within:ring-2 focus-within:ring-blue-100 dark:focus-within:ring-blue-500/20 focus-within:border-blue-400 dark:focus-within:border-blue-500">
+                    <div className="relative">
+                      <button
+                        type="button"
+                        className="pl-4 pr-3 py-2 text-sm text-gray-600 dark:text-neutral-300 font-medium border-r border-gray-200 dark:border-neutral-700 hover:text-blue-600 dark:hover:text-blue-400 flex items-center gap-1 transition-colors whitespace-nowrap"
+                        onClick={() => setIsSearchKindDropdownOpen((open) => !open)}
+                      >
+                        <span>{searchLabel}</span>
+                        <ChevronDownIcon className="w-3 h-3 text-gray-400 dark:text-neutral-500" />
+                      </button>
+
+                      {isSearchKindDropdownOpen && (
+                        <>
+                          <button
+                            type="button"
+                            aria-label="关闭搜索类型菜单"
+                            className="fixed inset-0 z-10 cursor-default"
+                            onClick={() => setIsSearchKindDropdownOpen(false)}
+                          />
+                          <div className="absolute top-full left-0 mt-2 w-32 bg-white dark:bg-neutral-900 rounded-lg shadow-lg border border-gray-100 dark:border-neutral-800 py-1 z-20 overflow-hidden">
+                            {SEARCH_OPTIONS.map((option) => (
+                              <button
+                                key={option.value}
+                                type="button"
+                                className={`w-full text-left px-4 py-2 text-sm transition-colors ${
+                                  searchType === option.value
+                                    ? "bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400 font-medium"
+                                    : "text-gray-600 dark:text-neutral-300 hover:bg-gray-50 dark:hover:bg-neutral-800"
+                                }`}
+                                onClick={() => {
+                                  setSearchType(option.value);
+                                  setIsSearchKindDropdownOpen(false);
+                                  setCurrentPage(1);
+                                }}
+                              >
+                                {option.label}
+                              </button>
+                            ))}
+                          </div>
+                        </>
+                      )}
+                    </div>
+
+                    <input
+                      type="text"
+                      className="flex-1 min-w-0 bg-transparent border-none focus:ring-0 pl-4 pr-10 py-2 text-sm text-gray-700 dark:text-neutral-100 placeholder-gray-400 dark:placeholder-neutral-500 focus:outline-none"
+                      placeholder="搜索..."
+                      value={keyword}
+                      onChange={(event) => {
+                        setKeyword(event.target.value);
+                        setCurrentPage(1);
+                      }}
+                    />
+                    {keyword ? (
+                      <button
+                        type="button"
+                        aria-label="清空搜索"
+                        onClick={() => {
+                          setKeyword("");
+                          setCurrentPage(1);
+                        }}
+                        className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 dark:text-neutral-500 hover:text-gray-600 dark:hover:text-neutral-300 transition-colors"
+                      >
+                        <X className="h-4 w-4" />
+                      </button>
+                    ) : (
+                      <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
+                        <Search className="h-4 w-4 text-gray-400 dark:text-neutral-500" />
+                      </div>
+                    )}
+                  </div>
+
+                  <button
+                    type="button"
+                    title="同步合集内容"
+                    aria-label="同步合集内容"
+                    onClick={() => refreshResources(selectedCollection)}
+                    disabled={isSyncingResources}
+                    className="p-2.5 rounded-full text-gray-500 bg-gray-50 border border-gray-200 hover:bg-gray-100 hover:text-pink-500 disabled:opacity-50 dark:text-neutral-400 dark:bg-neutral-800 dark:border-neutral-700 dark:hover:bg-neutral-700 dark:hover:text-pink-400 transition-colors"
+                  >
+                    <RefreshCw className={`w-4 h-4 ${isSyncingResources ? "animate-spin" : ""}`} />
+                  </button>
+                </div>
+              </section>
+
+              {isSyncingResources && resources.length === 0 ? (
+                <div className="text-center py-10 text-gray-500 dark:text-neutral-400">
+                  正在同步合集内容...
+                </div>
+              ) : (
+                <>
+                  <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-6">
+                    {currentResources.map((item) => (
+                      <a
+                        key={item.id}
+                        href={`https://www.bilibili.com/video/${item.bvid}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="border border-gray-200 dark:border-neutral-800 rounded-lg overflow-hidden flex flex-col bg-white dark:bg-neutral-900 hover:shadow-md transition-shadow no-underline text-inherit"
+                      >
+                        <div className="relative w-full aspect-video bg-gray-100 dark:bg-neutral-800">
+                          {item.cover ? (
+                            <img
+                              src={`${item.cover.replace("http:", "https:")}@760w_428h_1c.avif`}
+                              alt={item.title}
+                              className="w-full h-full object-cover"
+                              loading="lazy"
+                            />
+                          ) : (
+                            <div className="w-full h-full flex items-center justify-center text-gray-400 dark:text-neutral-500">
+                              <LibraryBig className="w-8 h-8" />
+                            </div>
+                          )}
+                        </div>
+                        <div className="p-3 flex-1 flex flex-col">
+                          <h3
+                            className="m-0 text-sm leading-[1.4] h-10 overflow-hidden line-clamp-2"
+                            title={item.title}
+                          >
+                            {item.title}
+                          </h3>
+                          <div className="flex justify-between items-center text-gray-500 dark:text-neutral-400 text-xs mt-2 gap-2">
+                            <button
+                              type="button"
+                              onClick={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                window.open(
+                                  `https://space.bilibili.com/${item.author_mid}`,
+                                  "_blank",
+                                );
+                              }}
+                              className="hover:text-[#fb7299] transition-colors cursor-pointer truncate text-left"
+                            >
+                              {item.author_name}
+                            </button>
+                            <span className="shrink-0">
+                              {item.pubdate
+                                ? new Date(item.pubdate * 1000).toLocaleDateString()
+                                : ""}
+                            </span>
+                          </div>
+                        </div>
+                      </a>
+                    ))}
+                  </div>
+
+                  {currentResources.length === 0 && (
+                    <div className="text-center py-16 text-gray-400 dark:text-neutral-500">
+                      这个合集暂时没有可显示的视频
+                    </div>
+                  )}
+
+                  <div className="mt-8">
+                    <Pagination
+                      currentPage={currentPage}
+                      totalItems={filteredResources.length}
+                      pageSize={pageSize}
+                      onPageChange={(page) => {
+                        setCurrentPage(page);
+                        contentRef.current?.scrollTo({ top: 0, behavior: "smooth" });
+                      }}
+                    />
+                  </div>
+                </>
+              )}
+            </>
+          ) : (
+            <div className="h-full min-h-[24rem] flex flex-col items-center justify-center text-gray-400 dark:text-neutral-500">
+              <LibraryBig className="w-12 h-12 mb-4" />
+              <p>{isSyncingCollections ? "正在同步订阅合集..." : "还没有订阅任何合集"}</p>
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default SubscribedCollections;

--- a/pages/WebDavSync.tsx
+++ b/pages/WebDavSync.tsx
@@ -19,6 +19,8 @@ import {
   getAllLikedMusic,
   getAllFavFolders,
   getAllFavResources,
+  getAllSubscribedCollections,
+  getAllSubscribedCollectionResources,
   saveHistory,
   importLikedMusic,
   importFavFolders,
@@ -26,15 +28,26 @@ import {
   smartMergeHistory,
   smartMergeLikedMusic,
   smartMergeFavResources,
+  importSubscribedCollections,
+  smartMergeSubscribedCollectionResources,
 } from "@/utils/db";
-import { HistoryItem, LikedMusic, FavoriteFolder, FavoriteResource } from "@/utils/types";
+import {
+  HistoryItem,
+  LikedMusic,
+  FavoriteFolder,
+  FavoriteResource,
+  SubscribedCollection,
+  SubscribedCollectionResource,
+} from "@/utils/types";
 
-/** WebDAV 同步的 4 个数据文件名 */
+/** WebDAV 同步的数据文件名 */
 const DATA_FILES = {
   history: "history.json",
   likedMusic: "likedMusic.json",
   favFolders: "favFolders.json",
   favResources: "favResources.json",
+  subscribedCollections: "subscribedCollections.json",
+  subscribedCollectionResources: "subscribedCollectionResources.json",
 } as const;
 
 /** 备份/恢复进度信息 */
@@ -137,32 +150,32 @@ const WebDavSync = () => {
     }
 
     setIsBackingUp(true);
-    setSyncProgress({ current: 0, total: 4, message: "准备备份数据..." });
+    setSyncProgress({ current: 0, total: 6, message: "准备备份数据..." });
 
     try {
       // 确保远程目录存在
       await ensureDirectory(config);
 
       // 1. 上传历史记录
-      setSyncProgress({ current: 0, total: 4, message: "正在备份历史记录..." });
+      setSyncProgress({ current: 0, total: 6, message: "正在备份历史记录..." });
       const history = await getAllHistory();
       const historyOk = await uploadFile(config, DATA_FILES.history, JSON.stringify(history));
       if (!historyOk) throw new Error("上传历史记录失败");
 
       // 2. 上传喜欢的音乐
-      setSyncProgress({ current: 1, total: 4, message: "正在备份喜欢的音乐..." });
+      setSyncProgress({ current: 1, total: 6, message: "正在备份喜欢的音乐..." });
       const music = await getAllLikedMusic();
       const musicOk = await uploadFile(config, DATA_FILES.likedMusic, JSON.stringify(music));
       if (!musicOk) throw new Error("上传喜欢的音乐失败");
 
       // 3. 上传收藏夹
-      setSyncProgress({ current: 2, total: 4, message: "正在备份收藏夹..." });
+      setSyncProgress({ current: 2, total: 6, message: "正在备份收藏夹..." });
       const folders = await getAllFavFolders();
       const foldersOk = await uploadFile(config, DATA_FILES.favFolders, JSON.stringify(folders));
       if (!foldersOk) throw new Error("上传收藏夹失败");
 
       // 4. 上传收藏资源
-      setSyncProgress({ current: 3, total: 4, message: "正在备份收藏资源..." });
+      setSyncProgress({ current: 3, total: 6, message: "正在备份收藏资源..." });
       const resources = await getAllFavResources();
       const resourcesOk = await uploadFile(
         config,
@@ -171,14 +184,34 @@ const WebDavSync = () => {
       );
       if (!resourcesOk) throw new Error("上传收藏资源失败");
 
+      // 5. 上传订阅合集
+      setSyncProgress({ current: 4, total: 6, message: "正在备份订阅合集..." });
+      const collections = await getAllSubscribedCollections();
+      const collectionsOk = await uploadFile(
+        config,
+        DATA_FILES.subscribedCollections,
+        JSON.stringify(collections),
+      );
+      if (!collectionsOk) throw new Error("上传订阅合集失败");
+
+      // 6. 上传订阅合集视频
+      setSyncProgress({ current: 5, total: 6, message: "正在备份合集视频..." });
+      const collectionResources = await getAllSubscribedCollectionResources();
+      const collectionResourcesOk = await uploadFile(
+        config,
+        DATA_FILES.subscribedCollectionResources,
+        JSON.stringify(collectionResources),
+      );
+      if (!collectionResourcesOk) throw new Error("上传合集视频失败");
+
       // 记录同步时间（数值时间戳）
       const now = Date.now();
       await setStorageValue(WEBDAV_LAST_SYNC, now);
       setLastSync(now);
 
-      setSyncProgress({ current: 4, total: 4, message: "备份完成！" });
+      setSyncProgress({ current: 6, total: 6, message: "备份完成！" });
       toast.success(
-        `备份完成！历史 ${history.length} 条，音乐 ${music.length} 首，收藏夹 ${folders.length} 个，收藏 ${resources.length} 项`,
+        `备份完成！历史 ${history.length} 条，音乐 ${music.length} 首，收藏夹 ${folders.length} 个，收藏 ${resources.length} 项，订阅合集 ${collections.length} 个，合集视频 ${collectionResources.length} 项`,
       );
     } catch (error: any) {
       console.error("WebDAV 备份失败:", error);
@@ -198,7 +231,7 @@ const WebDavSync = () => {
     }
 
     setIsBackingUp(true);
-    setSyncProgress({ current: 0, total: 8, message: "准备双向同步..." });
+    setSyncProgress({ current: 0, total: 12, message: "准备双向同步..." });
 
     try {
       await ensureDirectory(config);
@@ -207,7 +240,7 @@ const WebDavSync = () => {
       let totalMerged = 0;
       let totalSkipped = 0;
 
-      setSyncProgress({ current: 0, total: 8, message: "步骤 1/2：拉取历史记录..." });
+      setSyncProgress({ current: 0, total: 12, message: "步骤 1/2：拉取历史记录..." });
       const historyData = await downloadFile(config, DATA_FILES.history);
       if (historyData) {
         const items = JSON.parse(historyData) as HistoryItem[];
@@ -216,7 +249,7 @@ const WebDavSync = () => {
         totalSkipped += result.skipped;
       }
 
-      setSyncProgress({ current: 1, total: 8, message: "步骤 1/2：拉取喜欢的音乐..." });
+      setSyncProgress({ current: 1, total: 12, message: "步骤 1/2：拉取喜欢的音乐..." });
       const musicData = await downloadFile(config, DATA_FILES.likedMusic);
       if (musicData) {
         const items = JSON.parse(musicData) as LikedMusic[];
@@ -225,7 +258,7 @@ const WebDavSync = () => {
         totalSkipped += result.skipped;
       }
 
-      setSyncProgress({ current: 2, total: 8, message: "步骤 1/2：拉取收藏夹..." });
+      setSyncProgress({ current: 2, total: 12, message: "步骤 1/2：拉取收藏夹..." });
       const foldersData = await downloadFile(config, DATA_FILES.favFolders);
       if (foldersData) {
         const items = JSON.parse(foldersData) as FavoriteFolder[];
@@ -233,7 +266,7 @@ const WebDavSync = () => {
         totalMerged += items.length;
       }
 
-      setSyncProgress({ current: 3, total: 8, message: "步骤 1/2：拉取收藏资源..." });
+      setSyncProgress({ current: 3, total: 12, message: "步骤 1/2：拉取收藏资源..." });
       const resourcesData = await downloadFile(config, DATA_FILES.favResources);
       if (resourcesData) {
         const items = JSON.parse(resourcesData) as FavoriteResource[];
@@ -242,23 +275,43 @@ const WebDavSync = () => {
         totalSkipped += result.skipped;
       }
 
+      setSyncProgress({ current: 4, total: 12, message: "步骤 1/2：拉取订阅合集..." });
+      const collectionsData = await downloadFile(config, DATA_FILES.subscribedCollections);
+      if (collectionsData) {
+        const items = JSON.parse(collectionsData) as SubscribedCollection[];
+        await importSubscribedCollections(items);
+        totalMerged += items.length;
+      }
+
+      setSyncProgress({ current: 5, total: 12, message: "步骤 1/2：拉取合集视频..." });
+      const collectionResourcesData = await downloadFile(
+        config,
+        DATA_FILES.subscribedCollectionResources,
+      );
+      if (collectionResourcesData) {
+        const items = JSON.parse(collectionResourcesData) as SubscribedCollectionResource[];
+        const result = await smartMergeSubscribedCollectionResources(items);
+        totalMerged += result.merged;
+        totalSkipped += result.skipped;
+      }
+
       // 第二步：推送合并后的最新数据
-      setSyncProgress({ current: 4, total: 8, message: "步骤 2/2：推送历史记录..." });
+      setSyncProgress({ current: 6, total: 12, message: "步骤 2/2：推送历史记录..." });
       const history = await getAllHistory();
       const historyOk = await uploadFile(config, DATA_FILES.history, JSON.stringify(history));
       if (!historyOk) throw new Error("上传历史记录失败");
 
-      setSyncProgress({ current: 5, total: 8, message: "步骤 2/2：推送喜欢的音乐..." });
+      setSyncProgress({ current: 7, total: 12, message: "步骤 2/2：推送喜欢的音乐..." });
       const music = await getAllLikedMusic();
       const musicOk = await uploadFile(config, DATA_FILES.likedMusic, JSON.stringify(music));
       if (!musicOk) throw new Error("上传音乐失败");
 
-      setSyncProgress({ current: 6, total: 8, message: "步骤 2/2：推送收藏夹..." });
+      setSyncProgress({ current: 8, total: 12, message: "步骤 2/2：推送收藏夹..." });
       const folders = await getAllFavFolders();
       const foldersOk = await uploadFile(config, DATA_FILES.favFolders, JSON.stringify(folders));
       if (!foldersOk) throw new Error("上传收藏夹失败");
 
-      setSyncProgress({ current: 7, total: 8, message: "步骤 2/2：推送收藏资源..." });
+      setSyncProgress({ current: 9, total: 12, message: "步骤 2/2：推送收藏资源..." });
       const resources = await getAllFavResources();
       const resourcesOk = await uploadFile(
         config,
@@ -267,13 +320,31 @@ const WebDavSync = () => {
       );
       if (!resourcesOk) throw new Error("上传收藏资源失败");
 
+      setSyncProgress({ current: 10, total: 12, message: "步骤 2/2：推送订阅合集..." });
+      const collections = await getAllSubscribedCollections();
+      const collectionsOk = await uploadFile(
+        config,
+        DATA_FILES.subscribedCollections,
+        JSON.stringify(collections),
+      );
+      if (!collectionsOk) throw new Error("上传订阅合集失败");
+
+      setSyncProgress({ current: 11, total: 12, message: "步骤 2/2：推送合集视频..." });
+      const collectionResources = await getAllSubscribedCollectionResources();
+      const collectionResourcesOk = await uploadFile(
+        config,
+        DATA_FILES.subscribedCollectionResources,
+        JSON.stringify(collectionResources),
+      );
+      if (!collectionResourcesOk) throw new Error("上传合集视频失败");
+
       const now = Date.now();
       await setStorageValue(WEBDAV_LAST_SYNC, now);
       setLastSync(now);
 
-      setSyncProgress({ current: 8, total: 8, message: "双向同步完成！" });
+      setSyncProgress({ current: 12, total: 12, message: "双向同步完成！" });
       toast.success(
-        `双向同步完成！合并 ${totalMerged} 条，跳过 ${totalSkipped} 条，推送 ${history.length + music.length + folders.length + resources.length} 条`,
+        `双向同步完成！合并 ${totalMerged} 条，跳过 ${totalSkipped} 条，推送 ${history.length + music.length + folders.length + resources.length + collections.length + collectionResources.length} 条`,
       );
     } catch (error: any) {
       console.error("WebDAV 双向同步失败:", error);
@@ -293,14 +364,14 @@ const WebDavSync = () => {
     }
 
     setIsRestoring(true);
-    setSyncProgress({ current: 0, total: 4, message: "正在从 WebDAV 下载数据..." });
+    setSyncProgress({ current: 0, total: 6, message: "正在从 WebDAV 下载数据..." });
 
     try {
       let totalMerged = 0;
       let totalSkipped = 0;
 
       // 1. 恢复历史记录
-      setSyncProgress({ current: 0, total: 4, message: "正在恢复历史记录..." });
+      setSyncProgress({ current: 0, total: 6, message: "正在恢复历史记录..." });
       const historyData = await downloadFile(config, DATA_FILES.history);
       if (historyData) {
         const items = JSON.parse(historyData) as HistoryItem[];
@@ -310,7 +381,7 @@ const WebDavSync = () => {
       }
 
       // 2. 恢复喜欢的音乐
-      setSyncProgress({ current: 1, total: 4, message: "正在恢复喜欢的音乐..." });
+      setSyncProgress({ current: 1, total: 6, message: "正在恢复喜欢的音乐..." });
       const musicData = await downloadFile(config, DATA_FILES.likedMusic);
       if (musicData) {
         const items = JSON.parse(musicData) as LikedMusic[];
@@ -320,7 +391,7 @@ const WebDavSync = () => {
       }
 
       // 3. 恢复收藏夹（直接 upsert，无时间戳比对）
-      setSyncProgress({ current: 2, total: 4, message: "正在恢复收藏夹..." });
+      setSyncProgress({ current: 2, total: 6, message: "正在恢复收藏夹..." });
       const foldersData = await downloadFile(config, DATA_FILES.favFolders);
       if (foldersData) {
         const items = JSON.parse(foldersData) as FavoriteFolder[];
@@ -329,11 +400,33 @@ const WebDavSync = () => {
       }
 
       // 4. 恢复收藏资源
-      setSyncProgress({ current: 3, total: 4, message: "正在恢复收藏资源..." });
+      setSyncProgress({ current: 3, total: 6, message: "正在恢复收藏资源..." });
       const resourcesData = await downloadFile(config, DATA_FILES.favResources);
       if (resourcesData) {
         const items = JSON.parse(resourcesData) as FavoriteResource[];
         const result = await smartMergeFavResources(items);
+        totalMerged += result.merged;
+        totalSkipped += result.skipped;
+      }
+
+      // 5. 恢复订阅合集
+      setSyncProgress({ current: 4, total: 6, message: "正在恢复订阅合集..." });
+      const collectionsData = await downloadFile(config, DATA_FILES.subscribedCollections);
+      if (collectionsData) {
+        const items = JSON.parse(collectionsData) as SubscribedCollection[];
+        await importSubscribedCollections(items);
+        totalMerged += items.length;
+      }
+
+      // 6. 恢复订阅合集视频
+      setSyncProgress({ current: 5, total: 6, message: "正在恢复合集视频..." });
+      const collectionResourcesData = await downloadFile(
+        config,
+        DATA_FILES.subscribedCollectionResources,
+      );
+      if (collectionResourcesData) {
+        const items = JSON.parse(collectionResourcesData) as SubscribedCollectionResource[];
+        const result = await smartMergeSubscribedCollectionResources(items);
         totalMerged += result.merged;
         totalSkipped += result.skipped;
       }
@@ -343,7 +436,7 @@ const WebDavSync = () => {
       await setStorageValue(WEBDAV_LAST_SYNC, now);
       setLastSync(now);
 
-      setSyncProgress({ current: 4, total: 4, message: "恢复完成！" });
+      setSyncProgress({ current: 6, total: 6, message: "恢复完成！" });
       toast.success(`恢复完成！合并 ${totalMerged} 条，跳过 ${totalSkipped} 条（本地更新）`);
     } catch (error: any) {
       console.error("WebDAV 恢复失败:", error);
@@ -366,6 +459,8 @@ const WebDavSync = () => {
         likedMusic: await getAllLikedMusic(),
         favFolders: await getAllFavFolders(),
         favResources: await getAllFavResources(),
+        subscribedCollections: await getAllSubscribedCollections(),
+        subscribedCollectionResources: await getAllSubscribedCollectionResources(),
       };
 
       const json = JSON.stringify(data, null, 2);
@@ -380,7 +475,7 @@ const WebDavSync = () => {
       URL.revokeObjectURL(url);
 
       toast.success(
-        `导出成功！历史 ${data.history.length} 条，音乐 ${data.likedMusic.length} 首，收藏夹 ${data.favFolders.length} 个，收藏 ${data.favResources.length} 项`,
+        `导出成功！历史 ${data.history.length} 条，音乐 ${data.likedMusic.length} 首，收藏夹 ${data.favFolders.length} 个，收藏 ${data.favResources.length} 项，订阅合集 ${data.subscribedCollections.length} 个，合集视频 ${data.subscribedCollectionResources.length} 项`,
       );
     } catch (error) {
       console.error("导出数据失败:", error);
@@ -433,6 +528,20 @@ const WebDavSync = () => {
               }
               if (data.favResources && Array.isArray(data.favResources)) {
                 const resResult = await smartMergeFavResources(data.favResources);
+                totalMerged += resResult.merged;
+                totalSkipped += resResult.skipped;
+              }
+              if (data.subscribedCollections && Array.isArray(data.subscribedCollections)) {
+                await importSubscribedCollections(data.subscribedCollections);
+                totalMerged += data.subscribedCollections.length;
+              }
+              if (
+                data.subscribedCollectionResources &&
+                Array.isArray(data.subscribedCollectionResources)
+              ) {
+                const resResult = await smartMergeSubscribedCollectionResources(
+                  data.subscribedCollectionResources,
+                );
                 totalMerged += resResult.merged;
                 totalSkipped += resResult.skipped;
               }

--- a/pages/WebDavSync.tsx
+++ b/pages/WebDavSync.tsx
@@ -971,7 +971,8 @@ const WebDavSync = () => {
 
           <div className="mt-4 p-3 bg-gray-50 dark:bg-neutral-800 rounded-lg border border-gray-200 dark:border-neutral-700">
             <p className="text-xs text-gray-600 dark:text-neutral-300">
-              <strong>说明：</strong>导出文件包含历史记录、喜欢的音乐、收藏夹和收藏资源的完整数据。
+              <strong>说明：</strong>
+              导出文件包含历史记录、喜欢的音乐、收藏夹、收藏资源、订阅合集和合集视频的完整数据。
               导入时会智能合并，同时兼容旧版导出的单独历史记录或音乐 JSON 文件。
             </p>
           </div>

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -1042,6 +1042,26 @@ export const getSubscribedCollectionResources = async (
   });
 };
 
+/** 获取所有订阅合集 */
+export const getAllSubscribedCollections = async (): Promise<SubscribedCollection[]> => {
+  return getSubscribedCollections();
+};
+
+/** 获取所有订阅合集资源 */
+export const getAllSubscribedCollectionResources = async (): Promise<
+  SubscribedCollectionResource[]
+> => {
+  const db = await openDB();
+  const tx = db.transaction("subscribedCollectionResources", "readonly");
+  const store = tx.objectStore("subscribedCollectionResources");
+
+  return new Promise((resolve, reject) => {
+    const request = store.getAll();
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+};
+
 export const deleteFavResources = async (ids: number[]): Promise<void> => {
   const db = await openDB();
   const tx = db.transaction("favResources", "readwrite");
@@ -1148,6 +1168,26 @@ export const importFavResources = async (resources: FavoriteResource[]): Promise
       store.put(res);
     });
 
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+};
+
+/** 批量导入订阅合集（直接 upsert，按合集信息覆盖） */
+export const importSubscribedCollections = async (
+  collections: SubscribedCollection[],
+): Promise<void> => {
+  const db = await openDB();
+  const tx = db.transaction("subscribedCollections", "readwrite");
+  const store = tx.objectStore("subscribedCollections");
+
+  return new Promise((resolve, reject) => {
+    if (collections.length === 0) {
+      resolve();
+      return;
+    }
+
+    collections.forEach((collection) => store.put(collection));
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);
   });
@@ -1291,6 +1331,48 @@ export const smartMergeFavResources = async (
         store.put(remoteItem);
         merged++;
         processed++;
+      };
+    });
+
+    tx.oncomplete = () => resolve({ merged, skipped });
+    tx.onerror = () => reject(tx.error);
+  });
+};
+
+/**
+ * 智能合并订阅合集资源：按视频发布时间比对。
+ * 视频发布时间通常不可变；时间相同则以远端数据为准，补齐可能更新的标题或封面。
+ */
+export const smartMergeSubscribedCollectionResources = async (
+  remoteItems: SubscribedCollectionResource[],
+): Promise<{ merged: number; skipped: number }> => {
+  const db = await openDB();
+  const tx = db.transaction("subscribedCollectionResources", "readwrite");
+  const store = tx.objectStore("subscribedCollectionResources");
+  let merged = 0;
+  let skipped = 0;
+
+  return new Promise((resolve, reject) => {
+    if (remoteItems.length === 0) {
+      resolve({ merged: 0, skipped: 0 });
+      return;
+    }
+
+    remoteItems.forEach((remoteItem) => {
+      const getReq = store.get(remoteItem.id);
+      getReq.onsuccess = () => {
+        const localItem = getReq.result as SubscribedCollectionResource | undefined;
+
+        if (!localItem || remoteItem.pubdate >= localItem.pubdate) {
+          store.put(remoteItem);
+          merged++;
+        } else {
+          skipped++;
+        }
+      };
+      getReq.onerror = () => {
+        store.put(remoteItem);
+        merged++;
       };
     });
 

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -1,9 +1,15 @@
-import { DBConfig, HistoryItem, LikedMusic } from "./types";
+import {
+  DBConfig,
+  HistoryItem,
+  LikedMusic,
+  SubscribedCollection,
+  SubscribedCollectionResource,
+} from "./types";
 import dayjs from "dayjs";
 
 const DB_CONFIG: DBConfig = {
   name: "bilibiliHistory",
-  version: 5,
+  version: 6,
   stores: {
     history: {
       keyPath: "id",
@@ -20,6 +26,14 @@ const DB_CONFIG: DBConfig = {
     favResources: {
       keyPath: "id",
       indexes: ["folder_id", "fav_time"],
+    },
+    subscribedCollections: {
+      keyPath: "id",
+      indexes: ["mid"],
+    },
+    subscribedCollectionResources: {
+      keyPath: "id",
+      indexes: ["collection_id", "pubdate"],
     },
   },
 };
@@ -60,6 +74,20 @@ export const openDB = (): Promise<IDBDatabase> => {
         });
         favResourcesStore.createIndex("folder_id", "folder_id", { unique: false });
         favResourcesStore.createIndex("fav_time", "fav_time", { unique: false });
+
+        const subscribedCollectionsStore = db.createObjectStore("subscribedCollections", {
+          keyPath: "id",
+        });
+        subscribedCollectionsStore.createIndex("mid", "mid", { unique: false });
+
+        const subscribedCollectionResourcesStore = db.createObjectStore(
+          "subscribedCollectionResources",
+          { keyPath: "id" },
+        );
+        subscribedCollectionResourcesStore.createIndex("collection_id", "collection_id", {
+          unique: false,
+        });
+        subscribedCollectionResourcesStore.createIndex("pubdate", "pubdate", { unique: false });
 
         console.log("首次创建数据库和所有表");
       }
@@ -132,6 +160,24 @@ export const openDB = (): Promise<IDBDatabase> => {
         });
         favResourcesStore.createIndex("folder_id", "folder_id", { unique: false });
         favResourcesStore.createIndex("fav_time", "fav_time", { unique: false });
+      }
+
+      if (!db.objectStoreNames.contains("subscribedCollections")) {
+        const subscribedCollectionsStore = db.createObjectStore("subscribedCollections", {
+          keyPath: "id",
+        });
+        subscribedCollectionsStore.createIndex("mid", "mid", { unique: false });
+      }
+
+      if (!db.objectStoreNames.contains("subscribedCollectionResources")) {
+        const subscribedCollectionResourcesStore = db.createObjectStore(
+          "subscribedCollectionResources",
+          { keyPath: "id" },
+        );
+        subscribedCollectionResourcesStore.createIndex("collection_id", "collection_id", {
+          unique: false,
+        });
+        subscribedCollectionResourcesStore.createIndex("pubdate", "pubdate", { unique: false });
       }
     };
   });
@@ -925,6 +971,72 @@ export const getFavResources = async (folderId?: number): Promise<FavoriteResour
     } else {
       request = store.getAll();
     }
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+};
+
+export const replaceSubscribedCollections = async (
+  collections: SubscribedCollection[],
+): Promise<void> => {
+  const db = await openDB();
+  const tx = db.transaction("subscribedCollections", "readwrite");
+  const store = tx.objectStore("subscribedCollections");
+
+  return new Promise((resolve, reject) => {
+    const clearRequest = store.clear();
+    clearRequest.onsuccess = () => {
+      collections.forEach((collection) => store.put(collection));
+    };
+    clearRequest.onerror = () => reject(clearRequest.error);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+};
+
+export const getSubscribedCollections = async (): Promise<SubscribedCollection[]> => {
+  const db = await openDB();
+  const tx = db.transaction("subscribedCollections", "readonly");
+  const store = tx.objectStore("subscribedCollections");
+
+  return new Promise((resolve, reject) => {
+    const request = store.getAll();
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+};
+
+export const replaceSubscribedCollectionResources = async (
+  collectionId: number,
+  resources: SubscribedCollectionResource[],
+): Promise<void> => {
+  const db = await openDB();
+  const tx = db.transaction("subscribedCollectionResources", "readwrite");
+  const store = tx.objectStore("subscribedCollectionResources");
+  const collectionIndex = store.index("collection_id");
+
+  return new Promise((resolve, reject) => {
+    const existingKeysRequest = collectionIndex.getAllKeys(collectionId);
+    existingKeysRequest.onsuccess = () => {
+      existingKeysRequest.result.forEach((key) => store.delete(key));
+      resources.forEach((resource) => store.put(resource));
+    };
+    existingKeysRequest.onerror = () => reject(existingKeysRequest.error);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+};
+
+export const getSubscribedCollectionResources = async (
+  collectionId: number,
+): Promise<SubscribedCollectionResource[]> => {
+  const db = await openDB();
+  const tx = db.transaction("subscribedCollectionResources", "readonly");
+  const store = tx.objectStore("subscribedCollectionResources");
+  const collectionIndex = store.index("collection_id");
+
+  return new Promise((resolve, reject) => {
+    const request = collectionIndex.getAll(collectionId);
     request.onsuccess = () => resolve(request.result);
     request.onerror = () => reject(request.error);
   });

--- a/utils/types/index.ts
+++ b/utils/types/index.ts
@@ -45,6 +45,14 @@ export interface DBConfig {
       keyPath: string;
       indexes: string[];
     };
+    subscribedCollections: {
+      keyPath: string;
+      indexes: string[];
+    };
+    subscribedCollectionResources: {
+      keyPath: string;
+      indexes: string[];
+    };
   };
 }
 
@@ -93,4 +101,35 @@ export interface FavoriteResource {
   bvid: string;
   folder_id: number; // 关联的收藏夹ID
   index: number; // 在收藏夹中的顺序
+}
+
+export interface SubscribedCollection {
+  id: number;
+  mid: number;
+  title: string;
+  cover: string;
+  intro: string;
+  ctime: number;
+  mtime: number;
+  media_count: number;
+  upper: {
+    mid: number;
+    name: string;
+    face: string;
+  };
+  index: number;
+}
+
+export interface SubscribedCollectionResource {
+  id: string;
+  collection_id: number;
+  aid: number;
+  bvid: string;
+  title: string;
+  cover: string;
+  duration: number;
+  author_name: string;
+  author_mid: number;
+  pubdate: number;
+  index: number;
 }


### PR DESCRIPTION
## 新增：订阅合集管理

新增“合集”页面，用于查看用户收藏的 B 站视频合集及其中的视频内容。

### 改动内容

- 侧边栏新增“合集”入口，可在设置中隐藏
- 新增订阅合集列表与视频卡片展示
- 支持合集内视频搜索、分页和手动刷新
- 新增本地 IndexedDB 缓存，减少重复请求
- 使用 B 站收藏合集接口获取合集及视频数据
- WebDAV 备份、恢复、双向同步、导出/导入中加入：
  - `subscribedCollections.json`
  - `subscribedCollectionResources.json`
  
### 演示
<img width="2880" height="1462" alt="image" src="https://github.com/user-attachments/assets/132c2027-a417-451c-974f-fed133b96ce3" />

### 数据说明

合集与合集视频会缓存至本地，并参与 WebDAV 与本地导出/导入。已有旧备份不包含这两个文件时，恢复流程仍可正常兼容。

### PS:我没有修改更新日志的部分，需要您进行补充下哈~